### PR TITLE
Add program page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,8 +91,8 @@ conference:
         relative_url: /call4papers/
       - name: Registration
         relative_url: /registration/
-      # - name: Program
-      #   relative_url: /program/
+      - name: Program
+        relative_url: /program/
       # - live: true
       # - name: Speakers
       #   relative_url: /speakers/

--- a/program/index.md
+++ b/program/index.md
@@ -1,6 +1,23 @@
 ---
-layout: program
+layout: default
 title: "Program"
 ---
 
 <!-- The main categories (or tracks) of the different talks as well as their coloring can be adapted in the `_config.yml` file under `conference.talks.main_categories`. See also the [Talk Settings](https://github.com/DigitaleGesellschaft/jekyll-theme-conference/#talk-settings-main-categories) section of the theme's README file. -->
+
+# Program
+
+<br>
+
+#### Talks and Poster Sessions
+Schedule to be announced at a later time. Please see the [Call for Papers](../call4papers) page for more information on how to submit your research to the workshop.
+
+<br>
+
+#### Hackathon
+There will be a hackathon featuring a tutorial and a hands-on session focused on MIR applications in Latin American music. Participants will have the opportunity to work with Latin American datasets and develop AI tools and data loaders that contribute to the MIR and Music-AI community.
+
+<br>
+
+#### Music Program
+The workshop will have a music program with some local tunes, such as Brazilian samba.


### PR DESCRIPTION
- Add the program page with information about the hackathon and music program
- The program page is using the `default` layout, when the schedule is ready we will have to change it back to `program` layout